### PR TITLE
Adding ability to pass port into constructor. Also use better temp dir for config.

### DIFF
--- a/openfin/api/client.py
+++ b/openfin/api/client.py
@@ -21,9 +21,9 @@ class OpenFinClient(SystemAPIMixin):
     Public interface to connect to OpenFin
     """
 
-    def __init__( self, backend=OpenFinTornadoWebSocket ):
+    def __init__( self, backend=OpenFinTornadoWebSocket, port=None ):
         self._backend_class = backend
-        port = self._get_port()        
+        port = port or self._get_port()
         self.url = 'ws://localhost:'+str(port)+'/'        
         self.connect()
 
@@ -56,16 +56,16 @@ class OpenFinClient(SystemAPIMixin):
                 "version": "9.61.32.38"
             },
         }        
-        with open('my_config.json', 'w') as outfile:  
-            json.dump(config_json, outfile)                    
-        filename = os.path.join( os.getcwd(), 'my_config.json' )
+        config_file_path = os.path.join( os.environ.get('TMP') or os.getcwd(), 'my_config.json' )
+        with open(config_file_path, 'w') as outfile:
+            json.dump(config_json, outfile) 
 
         # Define the command and run it
         runtimeArgs = "--runtime-arguments=--runtime-information-channel-v6=" + self._pipe_name        
         cmd = [
             '{}'.format(OPENFIN_RVM_EXECUTABLE),
             '--launch',
-            '--config={}'.format(filename),
+            '--config={}'.format(config_file_path),
             runtimeArgs,
             ]        
         call( cmd )        


### PR DESCRIPTION
Adding ability to pass the port number into the python adapter constructor. 

Additionally using a different temp directory path, where available. This avoids write-permission issues on Windows when running the parent process from a different drive.